### PR TITLE
Fix upsert logic in check count

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -397,7 +397,7 @@ const upgrade = connection => {
               this.escape(row[uniqueKey]),
             [],
             (err, count) => {
-              if (count === 1) this.update(table, row, callback);
+              if (parseInt(count, 10) === 1) this.update(table, row, callback);
               else this.insert(table, row, callback);
             }
           );


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

I found and fix that `count` has `string` type, so below line is always false.

https://github.com/tshemsedinov/node-mysql-utilities/blob/e829aa19d76ccf81e451f7420322f60b423650d2/utilities.js#L400

- [ ] tests and linter show no problems (`npm t`)
  - Please tell me how to run test locally. 
- [ ] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
