### PR TITLE
Update utilities.js - Added null handling on return of null in where …

### DIFF
--- a/utilities.js
+++ b/utilities.js
@@ -85,7 +85,9 @@ const upgrade = connection => {
           result.push(`${key} = ${value.toString()}`);
         } else if (typeof value === 'string') {
           result.push(buildCondition(key, value, s => this.escape(s)));
-        }
+        } else if (value === null) {
+		      result.push(`${key} IS NULL`);
+		    }
       }
       return result.join(' AND ');
     };


### PR DESCRIPTION
…condition

Beforehand, a return of null on a where condition would return everything. However, now on return of null, the where condition yields null for affected tables.

<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

- [X] tests and linter show no problems (`npm t`)
- [X] tests are added/updated for bug fixes and new features
- [X] code is properly formatted (`npm run fmt`)
